### PR TITLE
feat: add dependency management for enet and lmdb in CMake configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,12 +5,8 @@ include(FetchContent)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # Dependencies
-FetchContent_Declare(
-    enet
-    GIT_REPOSITORY https://github.com/lsalzman/enet.git
-    GIT_TAG v1.3.18
-)
-FetchContent_MakeAvailable(enet)
+include(Dependencies.cmake)
+bhServer_setup_dependencies()
 
 # GNUstep configuration (non-Apple UNIX)
 if(UNIX AND NOT APPLE)
@@ -186,6 +182,7 @@ if(WIN32)
         objc
         dispatch
         enet
+        lmdb
     )
 
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fobjc-runtime=gnustep-2.2")
@@ -210,6 +207,7 @@ elseif(APPLE)
         "-framework Foundation"
         "-framework Cocoa"
         enet
+        lmdb
     )
 
     target_compile_options(${PROJECT_NAME} PRIVATE
@@ -223,6 +221,7 @@ elseif(UNIX AND NOT APPLE)
         objc
         dispatch
         enet
+        lmdb
     )
     set(CMAKE_C_COMPILER clang)
     set(CMAKE_CXX_COMPILER clang++)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,17 @@
 cmake_minimum_required(VERSION 3.29)
-project(BlockheadsServer LANGUAGES C CXX OBJC OBJCXX)
 include(FetchContent)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+set(USE_CCACHE OFF) # Currently not working.
+
+project(BlockheadsServer
+    VERSION 0.0.1
+    DESCRIPTION "Blockheads Server Decompilation Project"
+    HOMEPAGE_URL "https://floofyplasma.github.io/bh-server/"
+    LANGUAGES C CXX OBJC OBJCXX
+)
 
 # Dependencies
 include(Dependencies.cmake)

--- a/Dependencies.cmake
+++ b/Dependencies.cmake
@@ -25,4 +25,6 @@ function(bhServer_setup_dependencies)
         )
     endif()
 
+    cpmaddpackage("gh:TheLartians/Ccache.cmake@1.2.5")
+
 endfunction()

--- a/Dependencies.cmake
+++ b/Dependencies.cmake
@@ -1,0 +1,28 @@
+include(cmake/CPM.cmake)
+CPMUsePackageLock(package-lock.cmake)
+
+function(bhServer_setup_dependencies)
+
+    if(NOT TARGET enet)
+        cpmaddpackage("gh:lsalzman/enet@1.3.18")
+    endif()
+
+    if(NOT TARGET lmdb)
+        cpmaddpackage(
+            NAME lmdb
+            GITHUB_REPOSITORY LMDB/lmdb
+            GIT_TAG "LMDB_0.9.31"
+            DOWNLOAD_ONLY YES
+        )
+
+        add_library(lmdb STATIC
+            ${lmdb_SOURCE_DIR}/libraries/liblmdb/mdb.c
+            ${lmdb_SOURCE_DIR}/libraries/liblmdb/midl.c
+        )
+
+        target_include_directories(lmdb PUBLIC
+            ${lmdb_SOURCE_DIR}/libraries/liblmdb
+        )
+    endif()
+
+endfunction()

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -1,0 +1,20 @@
+set(CPM_DOWNLOAD_VERSION 0.42.0)
+set(CPM_HASH_SUM "2020b4fc42dba44817983e06342e682ecfc3d2f484a581f11cc5731fbe4dce8a")
+
+if(CPM_SOURCE_CACHE)
+  set(CPM_DOWNLOAD_LOCATION "${CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+elseif(DEFINED ENV{CPM_SOURCE_CACHE})
+  set(CPM_DOWNLOAD_LOCATION "$ENV{CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+else()
+  set(CPM_DOWNLOAD_LOCATION "${CMAKE_BINARY_DIR}/cmake/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+endif()
+
+# Expand relative path. This is important if the provided path contains a tilde (~)
+get_filename_component(CPM_DOWNLOAD_LOCATION ${CPM_DOWNLOAD_LOCATION} ABSOLUTE)
+
+file(DOWNLOAD
+     https://github.com/cpm-cmake/CPM.cmake/releases/download/v${CPM_DOWNLOAD_VERSION}/CPM.cmake
+     ${CPM_DOWNLOAD_LOCATION} EXPECTED_HASH SHA256=${CPM_HASH_SUM}
+)
+
+include(${CPM_DOWNLOAD_LOCATION})

--- a/package-lock.cmake
+++ b/package-lock.cmake
@@ -1,0 +1,17 @@
+# CPM Package Lock
+# This file should be committed to version control
+
+# enet
+CPMDeclarePackage(enet
+  VERSION 1.3.18
+  GITHUB_REPOSITORY lsalzman/enet
+  SYSTEM YES
+  EXCLUDE_FROM_ALL YES
+)
+# lmdb (unversioned)
+# CPMDeclarePackage(lmdb
+#  NAME lmdb
+#  GIT_TAG LMDB_0.9.31
+#  DOWNLOAD_ONLY YES
+#  GITHUB_REPOSITORY LMDB/lmdb
+#)

--- a/package-lock.cmake
+++ b/package-lock.cmake
@@ -15,3 +15,10 @@ CPMDeclarePackage(enet
 #  DOWNLOAD_ONLY YES
 #  GITHUB_REPOSITORY LMDB/lmdb
 #)
+# Ccache.cmake
+CPMDeclarePackage(Ccache.cmake
+  VERSION 1.2.5
+  GITHUB_REPOSITORY TheLartians/Ccache.cmake
+  SYSTEM YES
+  EXCLUDE_FROM_ALL YES
+)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Centralized third-party dependency management and added a package lock for reproducible builds.
  * Linked a cross-platform embedded database library to ensure availability on Windows, macOS, and Linux.
  * Added build configuration items and a project metadata block (version, description, homepage).

* **Refactor**
  * Replaced ad-hoc dependency fetching with a unified, reusable dependency setup to simplify setup and maintenance.

No user-facing behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->